### PR TITLE
Update dcan-macaque-pipeline to v0.1.1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,7 +21,7 @@ COPY ["app", "/app"]
 RUN python3 -m pip install -r "/app/requirements.txt"
 
 # insert pipeline code
-RUN git clone -b 'hotfix-fs-nonnormt1' --single-branch --depth 1 https://github.com/DCAN-Labs/dcan-macaque-pipeline.git /opt/pipeline
+RUN git clone -b 'v0.1.1' --single-branch --depth 1 https://github.com/DCAN-Labs/dcan-macaque-pipeline.git /opt/pipeline
 
 # unless otherwise specified...
 ENV OMP_NUM_THREADS=1


### PR DESCRIPTION
Update dcan-macaque-pipeline to v0.1.1 (hotfix for v0.1.0; fixes a syntax error in FreeSurfer stage)