### PR TITLE
Dbp hotfix 03172022

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM dcanumn/internal-tools:dbp-hotfix-03172022
+FROM dcanumn/internal-tools:v1.0.8
 
 ARG DEBIAN_FRONTEND=noninteractive
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM dcanumn/internal-tools:v1.0.7
+FROM dcanumn/internal-tools:dbp-hotfix-03172022
 
 ARG DEBIAN_FRONTEND=noninteractive
 

--- a/SetupEnv.sh
+++ b/SetupEnv.sh
@@ -37,11 +37,11 @@ export MSMBin=${HCPPIPEDIR}/MSMBinaries
 
 # Set up DCAN Environment Variables
 export SCRATCHDIR=/tmp
-export MCRROOT=/opt/mcr/v96
+export MCRROOT=/opt/mcr/v92
 export DCANBOLDPROCDIR=/opt/dcan-tools/dcan_bold_proc
 export DCANBOLDPROCVER=DCANBOLDProc_v4.0.0
 export EXECSUMDIR=/opt/dcan-tools/executivesummary
-export MATLAB_PREFDIR=/tmp/.matlab/R2019a
+export MATLAB_PREFDIR=/tmp/.matlab/R2017a
 export ABCDTASKPREPDIR=/opt/dcan-tools/ABCD_tfMRI
 export CUSTOMCLEANDIR=/opt/dcan-tools/customclean
 

--- a/app/run.py
+++ b/app/run.py
@@ -25,7 +25,7 @@ NeuroImage, 62:782-90, 2012
 [6] Avants, BB et al. The Insight ToolKit image registration framework. Front
 Neuroinform. 2014 Apr 28;8:44. doi: 10.3389/fninf.2014.00044. eCollection 2014.
 """
-__version__ = "0.0.0"
+__version__ = "0.2.7"
 
 import argparse
 import os
@@ -446,6 +446,7 @@ def interface(bids_dir, output_dir, aseg=None, subject_list=None, session_list=N
 
         # run pipelines
         for stage in order:
+            print('nhp-abcd-bids-pipeline v%s' % __version__)
             print('running %s' % stage.__class__.__name__)
             print(stage)
             stage.run(ncpus)


### PR DESCRIPTION
Changes from v0.2.6:

**ENH**: Update to internal-tools v1.0.8 / dcan_bold_processing v4.0.10
**FIX**: bandstop filter now works when filter range exceeds Nyquist frequency
**ENH/FIX**: report correct pipeline version with --version; report pipeline version to stdout at beginning of each stage  