### PR TITLE
config system and basic automated workflow setup

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,6 +17,7 @@ jobs:
             export DOCKER_BUILDKIT=1
             sudo -E docker build . -t vanandrew/nhp-abcd-bids-pipeline -q
             sudo docker system prune -f
+          no_output_timeout: 3h
   run:
     machine: true
     resource_class: vanandrew/linux
@@ -25,5 +26,5 @@ jobs:
           command: |
             ls /data
             ls /output
-            sudo docker ps -a
-            
+            sudo docker run -it --rm --name baloo -v /data:/data -v /output:/output --entrypoint="ls /data" vanandrew/nhp-abcd-bids-pipeline
+          no_output_timeout: 3h

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,7 +11,10 @@ jobs:
     machine: true
     resource_class: vanandrew/linux
     steps:
+      - run: ssh-keyscan github.com >> ~/.ssh/known_hosts
       - checkout
+      - run: git submodule sync
+      - run: git submodule update --init
       - run:
           command: |
             ./tools/download-templates.sh

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,10 +3,25 @@ workflows:
   testing:
     jobs:
       - runner-test
+      - nhp-abcd
 jobs:
   runner-test:
     machine: true
     resource_class: vanandrew/linux
     steps:
       - run: echo "Hi I'm on Runners!"
-
+  nhp-abcd:
+    machine: true
+    resource_class: vanandrew/linux
+    steps:
+      - run:
+          command: |
+            ls /mnt/data
+            sudo apt-get update
+            sudo apt-get install -y ca-certificates curl gnupg lsb-release
+            sudo mkdir -p /etc/apt/keyrings
+            sudo curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo gpg --dearmor -o /etc/apt/keyrings/docker.gpg
+            sudo echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.gpg] https://download.docker.com/linux/ubuntu $(lsb_release -cs) stable" | sudo tee /etc/apt/sources.list.d/docker.list > /dev/null
+            sudo apt-get update
+            sudo apt-get install -y docker-ce docker-ce-cli containerd.io docker-compose-plugin
+            sudo docker ps -a

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -28,6 +28,7 @@ jobs:
             sudo docker run -it --rm --name baloo \
               -v ${NHP_DATA_MOUNTPOINT}:/data:ro \
               -v ${NHP_WRITABLE_MOUNTPOINT}:/output \
+              -v ${NHP_DATA_MOUNTPOINT}/dcan_nhp_parcellations_20210907/parcellations:/opt/dcan-tools/dcan_bold_proc/templates/parcellations:ro \
               vanandrew/nhp-abcd-bids-pipeline \
               /data/nhp_bids /output --config_file /data/configs/baloo_config.toml
-          no_output_timeout: 3h
+          no_output_timeout: 5h

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -14,6 +14,7 @@ jobs:
       - checkout
       - run:
           command: |
+            ./tools/download-templates.sh
             export DOCKER_BUILDKIT=1
             sudo -E docker build . -t vanandrew/nhp-abcd-bids-pipeline -q
             sudo docker system prune -f

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -24,7 +24,9 @@ jobs:
     steps:
       - run:
           command: |
-            ls /data
-            ls /output
-            sudo docker run -it --rm --name baloo -v /data:/data -v /output:/output --entrypoint="ls /data" vanandrew/nhp-abcd-bids-pipeline
+            sudo docker run -it --rm --name baloo \
+              -v ${NHP_DATA_MOUNTPOINT}:/data:ro \
+              -v ${NHP_WRITABLE_MOUNTPOINT}:/output \
+              vanandrew/nhp-abcd-bids-pipeline \
+              /data/nhp_bids /output --config_file /data/configs/baloo_config.toml
           no_output_timeout: 3h

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,27 +1,29 @@
 version: 2.1
 workflows:
-  testing:
+  build-and-run:
     jobs:
-      - runner-test
-      - nhp-abcd
+      - build
+      - run:
+          requires:
+            - build
 jobs:
-  runner-test:
+  build:
     machine: true
     resource_class: vanandrew/linux
     steps:
-      - run: echo "Hi I'm on Runners!"
-  nhp-abcd:
+      - checkout
+      - run:
+          command: |
+            export DOCKER_BUILDKIT=1
+            sudo -E docker build . -t vanandrew/nhp-abcd-bids-pipeline -q
+            sudo docker system prune -f
+  run:
     machine: true
     resource_class: vanandrew/linux
     steps:
       - run:
           command: |
-            ls /mnt/data
-            sudo apt-get update
-            sudo apt-get install -y ca-certificates curl gnupg lsb-release
-            sudo mkdir -p /etc/apt/keyrings
-            sudo curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo gpg --dearmor -o /etc/apt/keyrings/docker.gpg
-            sudo echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.gpg] https://download.docker.com/linux/ubuntu $(lsb_release -cs) stable" | sudo tee /etc/apt/sources.list.d/docker.list > /dev/null
-            sudo apt-get update
-            sudo apt-get install -y docker-ce docker-ce-cli containerd.io docker-compose-plugin
+            ls /data
+            ls /output
             sudo docker ps -a
+            

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,12 @@
+version: 2.1
+workflows:
+  testing:
+    jobs:
+      - runner-test
+jobs:
+  runner-test:
+    machine: true
+    resource_class: vanandrew/linux
+    steps:
+      - run: echo "Hi I'm on Runners!"
+

--- a/.gitignore
+++ b/.gitignore
@@ -162,3 +162,6 @@ cython_debug/
 # ignore templates/templates directory
 scripts/dcan_macaque_pipeline/global/templates.tar.gz
 scripts/dcan_macaque_pipeline/global/templates/
+
+# ignore project env file
+.env

--- a/Dockerfile
+++ b/Dockerfile
@@ -169,9 +169,7 @@ ENV MSMBINDIR=/opt/msm/Ubuntu
 ENV OMP_NUM_THREADS=8 SCRATCHDIR=/tmp/scratch ITK_GLOBAL_DEFAULT_NUMBER_OF_THREADS=8 TMPDIR=/tmp
 
 # install omni
-RUN git clone https://gitlab.com/vanandrew/omni.git && cd omni && \
-    git checkout 115ae8786ae000518432bbdf5aab2dbd4abc6ef0 && \
-    python3.9 -m pip install -e ./[extra]
+RUN python3.9 -m pip install omnineuro==2022.8.1
 
 # copy DCAN pipeline
 COPY ["scripts/dcan_macaque_pipeline", "/opt/pipeline"]

--- a/configs/Daphne_config.toml
+++ b/configs/Daphne_config.toml
@@ -1,0 +1,20 @@
+[nhp-abcd-bids-pipeline]
+subject_list = [ "Daphne",]
+collect = false
+ncpus = 1
+freesurfer_license = "/data/license.txt"
+bandstop = [ 11.0, 19.0,]
+max_cortical_thickness = 5
+norm_gm_std_dev_scale = 0.5
+norm_wm_std_dev_scale = 0.5
+norm_csf_std_dev_scale = 0.5
+make_white_from_norm_t1 = true
+single_pass_pial = false
+t1_brain_mask = "/data/dcan_macaque_T1w_masks/sub-Daphne_ses-20210914NORDIC_T1w_pre_mask_dilM_edit.nii.gz"
+t1_reg_method = "ANTS_NO_INTERMEDIATE"
+check_outputs_only = false
+print = false
+ignore_expected_outputs = false
+multi_template_dir = "/opt/pipeline/global/templates/JointLabelCouncil"
+norm_method = "ROI_IPS"
+skip_synth = false

--- a/configs/baloo_config.toml
+++ b/configs/baloo_config.toml
@@ -1,0 +1,20 @@
+[nhp-abcd-bids-pipeline]
+subject_list = [ "baloo",]
+collect = false
+ncpus = 1
+freesurfer_license = "/data/license.txt"
+bandstop = [ 20.0, 28.0,]
+max_cortical_thickness = 5
+norm_gm_std_dev_scale = 0.5
+norm_wm_std_dev_scale = 0.5
+norm_csf_std_dev_scale = 0.5
+make_white_from_norm_t1 = true
+single_pass_pial = false
+t1_brain_mask = "/data/dcan_macaque_T1w_masks/sub-baloo_ses-20210513_T1w_pre_mask_edit.nii.gz"
+t1_reg_method = "ANTS_NO_INTERMEDIATE"
+check_outputs_only = false
+print = false
+ignore_expected_outputs = false
+multi_template_dir = "/opt/pipeline/global/templates/JointLabelCouncil"
+norm_method = "ROI_IPS"
+skip_synth = false

--- a/configs/cannellini_config.toml
+++ b/configs/cannellini_config.toml
@@ -1,0 +1,20 @@
+[nhp-abcd-bids-pipeline]
+subject_list = [ "cannellini",]
+collect = false
+ncpus = 1
+freesurfer_license = "/data/license.txt"
+bandstop = [ 14.0, 18.0,]
+max_cortical_thickness = 5
+norm_gm_std_dev_scale = 0.5
+norm_wm_std_dev_scale = 0.5
+norm_csf_std_dev_scale = 0.5
+make_white_from_norm_t1 = true
+single_pass_pial = false
+t1_brain_mask = "/data/dcan_macaque_T1w_masks/sub-cannellini_ses-20200205_T1w_pre_mask_edit.nii.gz"
+t1_reg_method = "ANTS_NO_INTERMEDIATE"
+check_outputs_only = false
+print = false
+ignore_expected_outputs = false
+multi_template_dir = "/opt/pipeline/global/templates/JointLabelCouncil"
+norm_method = "ROI_IPS"
+skip_synth = false

--- a/configs/env
+++ b/configs/env
@@ -1,0 +1,4 @@
+# This file should be copied into the project root as .env
+CIRCLECI_API_TOKEN=
+NHP_DATA_MOUNTPOINT=/data/nil-bluearc/GMT/Andrew/nhp_testing/data
+NHP_WRITABLE_MOUNTPOINT=/data/nil-bluearc/GMT/Andrew/nhp_testing/output

--- a/configs/env
+++ b/configs/env
@@ -2,3 +2,4 @@
 CIRCLECI_API_TOKEN=
 NHP_DATA_MOUNTPOINT=/data/nil-bluearc/GMT/Andrew/nhp_testing/data
 NHP_WRITABLE_MOUNTPOINT=/data/nil-bluearc/GMT/Andrew/nhp_testing/output
+LAUNCH_AGENT_RUNNER_MAX_RUN_TIME=96h

--- a/configs/quill_config.toml
+++ b/configs/quill_config.toml
@@ -1,0 +1,20 @@
+[nhp-abcd-bids-pipeline]
+subject_list = [ "quill",]
+collect = false
+ncpus = 1
+freesurfer_license = "/data/license.txt"
+bandstop = [ 21.0, 29.0,]
+max_cortical_thickness = 5
+norm_gm_std_dev_scale = 0.5
+norm_wm_std_dev_scale = 0.5
+norm_csf_std_dev_scale = 0.5
+make_white_from_norm_t1 = true
+single_pass_pial = false
+t1_brain_mask = "/data/dcan_macaque_T1w_masks/sub-quill_ses-20200226_T1w_pre_mask_edit.nii.gz"
+t1_reg_method = "ANTS_NO_INTERMEDIATE"
+check_outputs_only = false
+print = false
+ignore_expected_outputs = false
+multi_template_dir = "/opt/pipeline/global/templates/JointLabelCouncil"
+norm_method = "ROI_IPS"
+skip_synth = false

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,17 @@
+version: "3.9"
+
+services:
+  circleci:
+    image: circleci/runner:launch-agent
+    container_name: circleci-runner
+    volumes:
+      - type: bind
+        source: /var/run/docker.sock
+        target: /var/run/docker.sock
+        read_only: true
+      - type: bind
+        source: ${NHP_DATA_MOUNTPOINT}
+        target: /mnt/data/
+    environment:
+      - CIRCLECI_API_TOKEN
+    restart: always

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -20,4 +20,5 @@ services:
       - CIRCLECI_API_TOKEN
       - NHP_DATA_MOUNTPOINT
       - NHP_WRITABLE_MOUNTPOINT
+      - LAUNCH_AGENT_RUNNER_MAX_RUN_TIME
     restart: always

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -18,4 +18,6 @@ services:
         target: /output
     environment:
       - CIRCLECI_API_TOKEN
+      - NHP_DATA_MOUNTPOINT
+      - NHP_WRITABLE_MOUNTPOINT
     restart: always

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,7 @@ version: "3.9"
 
 services:
   circleci:
-    image: circleci/runner:launch-agent
+    image: vanandrew/circleci-runner:latest
     container_name: circleci-runner
     volumes:
       - type: bind
@@ -11,7 +11,11 @@ services:
         read_only: true
       - type: bind
         source: ${NHP_DATA_MOUNTPOINT}
-        target: /mnt/data/
+        target: /data
+        read_only: true
+      - type: bind
+        source: ${NHP_WRITABLE_MOUNTPOINT}
+        target: /output
     environment:
       - CIRCLECI_API_TOKEN
     restart: always

--- a/docker/Dockerfile.circleci
+++ b/docker/Dockerfile.circleci
@@ -1,0 +1,16 @@
+FROM circleci/runner:launch-agent
+
+# set non-interactive frontend
+ENV DEBIAN_FRONTEND=noninteractive
+
+# install docker
+RUN sudo apt-get update && \
+    sudo apt-get install -y ca-certificates curl gnupg lsb-release && \
+    sudo mkdir -p /etc/apt/keyrings && \
+    sudo curl -fsSL https://download.docker.com/linux/ubuntu/gpg | \
+        sudo gpg --dearmor -o /etc/apt/keyrings/docker.gpg && \
+    sudo echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.gpg]"\
+        "https://download.docker.com/linux/ubuntu $(lsb_release -cs) stable" | \
+        sudo tee /etc/apt/sources.list.d/docker.list > /dev/null && \
+    sudo apt-get update && \
+    sudo apt-get install -y docker-ce docker-ce-cli containerd.io docker-compose-plugin

--- a/nhp_abcd/pipelines/fmri_volume.py
+++ b/nhp_abcd/pipelines/fmri_volume.py
@@ -233,6 +233,7 @@ def synth_distortion_correction(
     warpfield_afni_ab: str,
     anat_2_func_xfm_omni: str,
     fmap_skip: bool = False,
+    skip_synth: bool = False,
 ) -> str:
     """Synth Distortion Correction.
 
@@ -260,6 +261,8 @@ def synth_distortion_correction(
         Anatomical to functional transform in omni format.
     fmap_skip : bool
         skip distortion correction, returning previous transform
+    skip_synth : bool
+        skips synth distortion correction, returning topup transform
 
     Returns
     -------
@@ -280,47 +283,63 @@ def synth_distortion_correction(
     if fmap_skip:
         return func_2_anat_transform, jacobian_anat
 
-    # run Synth unwarping
-    results = synthunwarp(
-        output_path=os.path.join(output_path, "SynthOutput"),
-        t1_debias=t1_nm,
-        t2_debias=t2_nm,
-        anat_bet_mask=anat_brain_mask,
-        anat_eye_mask=None,
-        ref_epi=scout_debias_ab,
-        ref_epi_bet_mask=func_brain_mask_ab,
-        epi=func_nm_ab,
-        bandwidth=4,
-        resample_resolution=0.5,
-        resolution_pyramid=[0.5],
-        dilation_size=30,
-        skip_synthtarget_affine=True,
-        synthtarget_max_iterations=[100],
-        synthtarget_err_tol=[5e-4],
-        synthtarget_step_size=[1e-3],
-        distortion_correction_smoothing="0x0",
-        distortion_correction_shrink_factors="2x1",
-        distortion_correction_step_size=[1.5, 1, 0.5, 0.1],
-        noise_mask_iterations=1,
-        initial_warp_field=warpfield_afni_ab,
-        initial_affine=anat_2_func_xfm_omni,
-    )
+    # if skip synth enabled, just return the existing transform
+    if skip_synth:
+        # convert omni affine to fsl format
+        convert_affine_file(
+            func_2_anat_xfm_fsl, anat_2_func_xfm_omni, "fsl", invert=True, target=scout_debias_ab, source=t1_nm
+        )
+        # resample the warp from Autobox dims to standard dims
+        run_process(
+            f"3dresample -prefix {func_2_anat_warp_afni} "
+            f"-master {scout} -input {warpfield_afni_ab} -rmode Cu -overwrite"
+        )
+        # convert the warp to fsl format
+        convert_warp(nib.load(func_2_anat_warp_afni), "afni", "fsl", invert=False, target=nib.load(scout)).to_filename(
+            func_2_anat_warp_fsl
+        )
+    else:
+        # run Synth unwarping
+        results = synthunwarp(
+            output_path=os.path.join(output_path, "SynthOutput"),
+            t1_debias=t1_nm,
+            t2_debias=t2_nm,
+            anat_bet_mask=anat_brain_mask,
+            anat_eye_mask=None,
+            ref_epi=scout_debias_ab,
+            ref_epi_bet_mask=func_brain_mask_ab,
+            epi=func_nm_ab,
+            bandwidth=4,
+            resample_resolution=0.5,
+            resolution_pyramid=[0.5],
+            dilation_size=30,
+            skip_synthtarget_affine=True,
+            synthtarget_max_iterations=[100],
+            synthtarget_err_tol=[5e-4],
+            synthtarget_step_size=[1e-3],
+            distortion_correction_smoothing="0x0",
+            distortion_correction_shrink_factors="2x1",
+            distortion_correction_step_size=[1.5, 1, 0.5, 0.1],
+            noise_mask_iterations=1,
+            initial_warp_field=warpfield_afni_ab,
+            initial_affine=anat_2_func_xfm_omni,
+        )
 
-    # get the func to anat transforms
-    func_2_anat_xfm = results["final_epi_to_anat_affine"]
-    func_2_anat_warp = results["final_epi_to_synth_warp"]
+        # get the func to anat transforms
+        func_2_anat_xfm = results["final_epi_to_anat_affine"]
+        func_2_anat_warp = results["final_epi_to_synth_warp"]
 
-    # convert the affine into fsl format
-    convert_affine_file(func_2_anat_xfm_fsl, func_2_anat_xfm, "fsl", invert=False, target=t1_nm, source=scout)
+        # convert the affine into fsl format
+        convert_affine_file(func_2_anat_xfm_fsl, func_2_anat_xfm, "fsl", invert=False, target=t1_nm, source=scout)
 
-    # resample the warp from Autobox dims to standard dims
-    run_process(
-        f"3dresample -prefix {func_2_anat_warp_afni} -master {scout} -input {func_2_anat_warp} -rmode Cu -overwrite"
-    )
-    # convert the warp to fsl format
-    convert_warp(nib.load(func_2_anat_warp_afni), "afni", "fsl", invert=False, target=nib.load(scout)).to_filename(
-        func_2_anat_warp_fsl
-    )
+        # resample the warp from Autobox dims to standard dims
+        run_process(
+            f"3dresample -prefix {func_2_anat_warp_afni} -master {scout} -input {func_2_anat_warp} -rmode Cu -overwrite"
+        )
+        # convert the warp to fsl format
+        convert_warp(nib.load(func_2_anat_warp_afni), "afni", "fsl", invert=False, target=nib.load(scout)).to_filename(
+            func_2_anat_warp_fsl
+        )
 
     # sanity check: these two results should be the same
     run_process(
@@ -1040,6 +1059,7 @@ class FMRIVolume(DCANPipeline):
                 self.synth_stage.set_stage_arg("output_path", os.path.join("FieldMaps", fmap_prefix))
                 self.synth_stage.set_stage_arg("anat_brain_mask", os.path.join(T1wFolder, T1wBrainMask + ".nii.gz"))
                 self.synth_stage.set_stage_arg("fmap_skip", fmap_skip)
+                self.synth_stage.set_stage_arg("skip_synth", self.config.skip_synth)
 
                 # resample
                 fmrires = self.config.fmrires

--- a/nhp_abcd/pipelines/fmri_volume.py
+++ b/nhp_abcd/pipelines/fmri_volume.py
@@ -285,6 +285,9 @@ def synth_distortion_correction(
 
     # if skip synth enabled, just return the existing transform
     if skip_synth:
+        # Since we skip Synth, we need to ensure the SynthOutput folder is made
+        os.makedirs(os.path.join(output_path, "SynthOutput"), exist_ok=True)
+
         # convert omni affine to fsl format
         convert_affine_file(
             func_2_anat_xfm_fsl, anat_2_func_xfm_omni, "fsl", invert=True, source=scout, target=t1_nm

--- a/nhp_abcd/pipelines/pipelines.py
+++ b/nhp_abcd/pipelines/pipelines.py
@@ -224,6 +224,9 @@ class ParameterSettings(object):
         # FreeSurfer single pass pial
         self.single_pass_pial = "false"
 
+        # skip_synth
+        self.skip_synth: bool = False
+
     def __getitem__(self, item):
         return self._params()[item]
 

--- a/nhp_abcd/scripts/run.py
+++ b/nhp_abcd/scripts/run.py
@@ -27,6 +27,8 @@ Neuroinform. 2014 Apr 28;8:44. doi: 10.3389/fninf.2014.00044. eCollection 2014.
 import argparse
 import os
 
+from omni.scripts.common.command import set_common, parse_common
+
 from nhp_abcd import __version__
 from nhp_abcd.helpers import read_bids_dataset, validate_license
 from nhp_abcd.pipelines import (
@@ -49,7 +51,9 @@ def _cli():
     :return:
     """
     parser = generate_parser()
+    set_common(parser, threads=False, version=False)
     args = parser.parse_args()
+    parse_common(args, parser)
 
     return interface(
         args.bids_dir,
@@ -79,6 +83,7 @@ def _cli():
         args.single_pass_pial,
         args.registration_assist,
         args.freesurfer_license,
+        args.skip_synth,
     )
 
 
@@ -346,6 +351,11 @@ def generate_parser(parser=None):
         "normalization methods and then restart at FreeSurfer. "
         "Default: ADULT_GM_IP.",
     )
+    parser.add_argument(
+        "--skip_synth",
+        action="store_true",
+        help="Skip Synth distortion correction step in pipeline."
+    )
 
     return parser
 
@@ -378,6 +388,7 @@ def interface(
     single_pass_pial=False,
     registration_assist=None,
     freesurfer_license=None,
+    skip_synth=False,
 ):
     """
     main application interface
@@ -458,6 +469,9 @@ def interface(
             session_spec.set_templates_dir(multi_template_dir)
         if max_cortical_thickness != 5:
             session_spec.set_max_cortical_thickness(max_cortical_thickness)
+
+        # set skip_synth flag
+        session_spec.skip_synth = skip_synth
 
         # create pipelines
         mask = PreliminaryMasking(session_spec)


### PR DESCRIPTION
This pull request updates the `omni` dependency and adds a `--skip_synth` flag to disable Synth Distortion Correction, which only applies distortion correction from topup. In addition, it adds configuration file support and includes a basic continuous integration setup with circleci (though some parameters + config will be need on the compute end of things to get it truly working).

### Config files

The config system uses the [toml](https://toml.io/en/) format. Arguments can be specified in the config file, as shown in the following example:
```toml
[nhp-abcd-bids-pipeline]
subject_list = [ "baloo",]
collect = false
ncpus = 1
freesurfer_license = "/data/license.txt"
bandstop = [ 20.0, 28.0,]
max_cortical_thickness = 5
norm_gm_std_dev_scale = 0.5
norm_wm_std_dev_scale = 0.5
norm_csf_std_dev_scale = 0.5
make_white_from_norm_t1 = true
single_pass_pial = false
t1_brain_mask = "/data/dcan_macaque_T1w_masks/sub-baloo_ses-20210513_T1w_pre_mask_edit.nii.gz"
t1_reg_method = "ANTS_NO_INTERMEDIATE"
check_outputs_only = false
print = false
ignore_expected_outputs = false
multi_template_dir = "/opt/pipeline/global/templates/JointLabelCouncil"
norm_method = "ROI_IPS"
skip_synth = false
```
which can be passed into the program as:

```bash
docker run -it --rm \
-v ${NHP_DATA}:/data \
-v ${NHP_OUTPUT}:/output \
dcanumn/nhp-abcd-bids-pipeline \
/data /output --config_file config.toml
```
this is functionally equivalent to:

```bash
docker run -it --rm \
-v ${NHP_DATA}:/data \
-v ${NHP_OUTPUT}:/output \
dcanumn/nhp-abcd-bids-pipeline \
/data /output \
--freesurfer-license /data/license.txt \
--participant-label baloo \
--t1-brain-mask /data/dcan_macaque_T1w_masks/sub-baloo_ses-20210513_T1w_pre_mask_edit.nii.gz \
--t1-reg-method ANTS_NO_INTERMEDIATE \
--hyper-normalization-method ROI_IPS \
--norm-gm-std-dev-scale 0.5 \
--norm-wm-std-dev-scale 0.5 \
--norm-csf-std-dev-scale 0.5 \
--make-white-from-norm-t1 \
--bandstop 20 28 \
--multi-template-dir /opt/pipeline/global/templates/JointLabelCouncil
```

Arguments on the command-line take precedence over any arguments defined in the file, for example:

```bash
docker run -it --rm \
-v ${NHP_DATA}:/data \
-v ${NHP_OUTPUT}:/output \
dcanumn/nhp-abcd-bids-pipeline \
/data /output --config_file config.toml \
--ncpus 8
```
Will use `ncpus=8` rather than `ncpus=1` as in the config file.

### CI with circleci

This pull request contains a docker compose config for setting up a self-hosted runner for the circleci service. It can be run by copying over `env` file to the project root directory, and running `docker compose up -d`. This will register a dockerized runner with the circleci service (you will need to register a `CIRCLECI_API_TOKEN` for this to work).

The self-hosted runner passes the `docker.sock` socket from the host, so that docker images inside the runner can be used. When the workflow is triggered the pipeline docker image can use `NHP_DATA_MOUNT` and `NHP_WRITABLE_MOUNT` to read and write data to the host.

Host Machine ------------------------------------> circleci runner ------------------------------------> nhp-abcd-bids-pipeline
Docker&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Docker (mounting host `docker.sock`)
