### PR TITLE
internal-tools update

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM dcanumn/internal-tools:R2019a-test
+FROM dcanumn/internal-tools:v1.0.12
 
 ARG DEBIAN_FRONTEND=noninteractive
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM dcanumn/internal-tools:v1.0.10
+FROM dcanumn/internal-tools:R2019a-test
 
 ARG DEBIAN_FRONTEND=noninteractive
 

--- a/SetupEnv.sh
+++ b/SetupEnv.sh
@@ -37,11 +37,11 @@ export MSMBin=${HCPPIPEDIR}/MSMBinaries
 
 # Set up DCAN Environment Variables
 export SCRATCHDIR=/tmp
-export MCRROOT=/opt/mcr/v91
+export MCRROOT=/opt/mcr/v96
 export DCANBOLDPROCDIR=/opt/dcan-tools/dcan_bold_proc
 export DCANBOLDPROCVER=DCANBOLDProc_v4.0.0
 export EXECSUMDIR=/opt/dcan-tools/executivesummary
-export MATLAB_PREFDIR=/tmp/.matlab/R2016b
+export MATLAB_PREFDIR=/tmp/.matlab/R2019a
 export ABCDTASKPREPDIR=/opt/dcan-tools/ABCD_tfMRI
 export CUSTOMCLEANDIR=/opt/dcan-tools/customclean
 

--- a/app/run.py
+++ b/app/run.py
@@ -25,7 +25,7 @@ NeuroImage, 62:782-90, 2012
 [6] Avants, BB et al. The Insight ToolKit image registration framework. Front
 Neuroinform. 2014 Apr 28;8:44. doi: 10.3389/fninf.2014.00044. eCollection 2014.
 """
-__version__ = "0.2.11"
+__version__ = "0.2.12"
 
 import argparse
 import os


### PR DESCRIPTION
Bump internal-tools version from 1.0.10 -> 1.0.12, addressing two issues:
- Missing outlier .mat files in DCANBOLDProcessing
- Docker build failure due to broken NeuroDocker ANTs link